### PR TITLE
Uncaught SyntaxError: Unexpected token export

### DIFF
--- a/src/components/bodyParsing.js
+++ b/src/components/bodyParsing.js
@@ -182,4 +182,4 @@ function camelizeHeader (header) {
   })
 }
 
-export default { deriveBody, bodyWithIds, filterBody, sortBody, camelizeHeader }
+module.exports = { deriveBody, bodyWithIds, filterBody, sortBody, camelizeHeader }


### PR DESCRIPTION
Fix bodyParsing.js modular usage.
Export default {...} was got **Uncaught SyntaxError: Unexpected token export**.  Module.exports will fix that.

![screenshot](https://api.monosnap.com/rpc/file/download?id=Ux9svFZcaeO2KEtWVvRvEsFoQuKAHQ)